### PR TITLE
add cross-links to other repositories to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,32 @@
 # Chickenshock
 
-In this game, you have to shoot the chicken displaying the correct answer.  
 ![Chickenshock](https://raw.githubusercontent.com/Gamify-IT/docs/main/images/chickenshock.webp)
-
-Unity Version: 2021.3.2f1 (LTS)
+This repository contains the frontend for the [Chickenshock minigame](https://gamifyit-docs.readthedocs.io/en/latest/user-manuals/minigames/chickenshock.html).
 
 ## Disclaimer
 
 This project is developed as part of a student project at Universität Stuttgart.
 It may contain bugs, and is not licensed for external use.
 
+## Table of contents
+
+<!-- TOC -->
+* [Links](#links)
+* [Development](#development)
+  * [Getting started](#getting-started)
+  * [Run the project](#run-the-project)
+  * [Build](#build)
+<!-- TOC -->
+
+## Links
+
+- User documentation for the minigame can be found [here](https://gamifyit-docs.readthedocs.io/en/latest/user-manuals/minigames/chickenshock.html).
+- For the backend, see the [Gamify-IT/chickenshock-backend repository](https://github.com/Gamify-IT/chickenshock-backend).
+- The installation manual and setup instructions can be found [here](https://gamifyit-docs.readthedocs.io/en/latest/install-manuals/index.html).
+
 ## Development
+
+Unity Version: 2021.3.2f1 (LTS)
 
 ### Getting started
 
@@ -50,40 +66,3 @@ docker stop chickenshock-dev
 ```sh
 docker rm chickenshock-dev
 ```
-
-## User manual
-
-Run the docker container with the following command at port 8000:
-```sh
-docker run -d -p 8000:80 --name chickenshock ghcr.io/gamify-it/chickenshock:latest
-```
-Now you can access it at [http://localhost:8000](http://localhost:8000).  
-To access it externally replace localhost with your IP.  
-
-To monitor the container you can use the following command:
-```sh
-docker ps -a -f name=chickenshock
-```
-To stop the container you can use the following command:
-```sh
-docker stop chickenshock
-```
-To remove the container you can use the following command:
-```sh
-docker rm chickenshock
-```
-### Features
-
-- Questions are displayed at the top of the screen
-- Chickens run around with signs
-- Signs contain possible answers
-- Chickens can be shot
-- Mouse can be unlocked by pressing `p`
-- Points are credited for shooting the chicken with the correct answer
-- Points are deducted when shooting a chicken with the wrong answer
-- Score in one corner of the screen
-- After fixed time or fixed number of answered questions the game ends
-
-### Screenshot
-
-![screenshot](https://user-images.githubusercontent.com/44726248/171508596-16837ea1-f6ce-4b69-b12b-30b0452f917c.png)


### PR DESCRIPTION
Part of https://github.com/Gamify-IT/issues/issues/309
- add cross-links to backend and docs
- remove "user manual" which was outdated and not actually a user manual